### PR TITLE
Message api improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,741 +1,250 @@
 <h1 align="center">Codex SDK</h1>
-<p align="center">A flexible library for building powerful, interactive coding agents with pre-built UI and system tool integrations. This project is a fork of OpenAI's original <a href="https://github.com/openai/codex">Codex CLI</a>, refactored into a library to provide a foundation for custom agent development.</p>
+<p align="center"><b>Build powerful, human-in-the-loop terminal AI workflows.</b></p>
 
 ---
 
-## Core Concept
+## What is Codex SDK?
 
-The Codex SDK provides the foundational components—UI, system tool integrations, and an agent workflow framework—to create bespoke coding agents. Unlike a standalone CLI, this library empowers you to embed agent capabilities into your own applications or build highly customized agent experiences.
+While simple agent loops can run uninterrupted, the most powerful workflows involve collaboration. Codex SDK is designed specifically for building **human-in-the-loop** terminal agents that can ask questions, get feedback, and work alongside the user.
 
-You, the developer, provide the core agent logic (e.g., Large Language Model interaction, prompting strategies, and decision-making), and the library handles the interactive terminal UI, secure tool execution, and message orchestration.
+**Codex SDK handles the hard parts of interactive terminal UI, so you can focus on your agent's logic.**
 
-## Quickstart
+It's a lightweight framework for creating bespoke agents using the Vercel AI SDK v5. It provides a polished terminal UI, secure tool execution, and a minimal workflow API that makes building interactive, collaborative agents simple.
+
+Originally a fork of the OpenAI Codex CLI, this SDK has been refactored into a reusable library for building custom agentic workflows.
+
+### Core Features
+
+- **Human-in-the-Loop Interaction**: Build agents that can pause to ask questions, present options, and request confirmation from the user before proceeding.
+- **Secure Tool Execution**: Safely allow the agent to run terminal commands and modify files with a multi-level approval system that keeps the user in control.
+- **Advanced Terminal UI**: A polished, Ink-based interface for message history, multi-line input, status indicators, and more.
+- **Display Customization**: Tailor the look and feel of your agent with a powerful theming system, custom message rendering, and configurable headers and borders.
+- **Task Queue System**: Manage and display a queue of pending tasks to the user, providing transparency while the agent is processing.
+- **Flexible Agent Loop**: You own the agent logic. Plug into Vercel AI SDK v5 and any supported model provider (OpenAI, Anthropic, Google, etc.).
+
+### Requirements
+
+- Node >= 22
+- Vercel AI SDK v5 (`ai@^5`)
+- A model provider package (e.g., `@ai-sdk/openai`)
 
 ### Installation
 
-Add the Codex SDK to your project:
-
 ```shell
-npm install codex-sdk
-# or
-yarn add codex-sdk
-# or
-pnpm add codex-sdk
+pnpm add codex-sdk ai@^5
+# Add your preferred model provider
+pnpm add @ai-sdk/openai@^2
 ```
 
-### Example 1: Running the Default Agent
+## Quickstart: A Simple Agent in 20 Lines
 
-For a quick start with an experience similar to the original Codex CLI, you can use the `createDefaultWorkflow`. This sets up a pre-configured agent.
-
-```javascript
-// my-default-agent.js
-import { run, createDefaultWorkflow, AutoApprovalMode } from "codex-sdk";
-
-const defaultWorkflow = createDefaultWorkflow({
-  approvalPolicy: AutoApprovalMode.SUGGEST,
-  model: "openai/gpt-4o",
-});
-
-// Launch the agent UI with the default workflow
-run(defaultWorkflow);
-```
-
-### Example 2: Building a Custom Agent
-
-Create your own agent logic by providing a function to `createAgentWorkflow`. This function defines how your agent initializes, processes messages, and interacts with the UI and tools.
-
-**Timeout Functionality Example:**
+This example creates a helpful assistant that can use tools.
 
 ```javascript
-// Manual hook calls with timeout in your agent logic
-const confirmation = await hooks.onSelect(
-  [
-    { label: "Yes", value: "yes" },
-    { label: "No", value: "no" },
-  ],
-  {
-    label: "Continue with this action?",
-    timeout: 10,
-    defaultValue: "no",
-  },
-);
-
-const framework = await hooks.onSelect(
-  [
-    { label: "React", value: "react" },
-    { label: "Vue", value: "vue" },
-    { label: "Angular", value: "angular" },
-  ],
-  {
-    label: "What's your preferred framework?",
-    timeout: 30,
-    defaultValue: "react",
-  },
-);
-
-// LLM can also initiate user interactions autonomously via user_select tool
-// (timeout/defaultValue automatically included with 45s default)
-const response = await generateText({
-  model: openai("gpt-4o"),
-  messages: [...state.transcript],
-  tools, // Includes user_select for confirmations, prompts, and selections
-});
-```
-
-```javascript
-// my-custom-agent.js
+// minimal-agent.js
 import { run, createAgentWorkflow } from "codex-sdk";
-import { generateText } from "ai"; // Example: Using Vercel AI SDK
-import { openai } from "@ai-sdk/openai"; // Example: OpenAI provider
+import { generateText } from "ai";
+import { openai } from "@ai-sdk/openai";
 
-const customWorkflow = createAgentWorkflow(
-  ({ setState, state, appendMessage, handleToolCall, tools, onConfirm }) => {
-    let agentState = "idle"; // 'idle', 'running', 'paused'
-
-    async function processLoop() {
-      setState({ loading: true });
-      agentState = "running";
-
-      while (agentState === "running" && state.loading) {
-        try {
-          const response = await generateText({
-            model: openai("gpt-4o"), // Your chosen model
-            messages: [
-              { role: "system", content: "You are a helpful assistant." },
-              ...state.transcript, // Use filtered transcript (no UI messages)
-            ],
-            tools, // Pass the library's tools to the LLM
-          });
-
-          const aiResponseMessage = response.response.messages[0];
-
-          if (aiResponseMessage) {
-            // Add AI response to state (automatically appears in state.transcript)
-            appendMessage(aiResponseMessage);
-
-            const toolCallResult = await handleToolCall(aiResponseMessage); // Library handles tool execution
-
-            if (toolCallResult) {
-              appendMessage(toolCallResult);
-            } else if (response.finishReason === "stop") {
-              agentState = "paused";
-            }
-          } else {
-            agentState = "paused";
-          }
-        } catch (error) {
-          appendMessage({
-            role: "ui",
-            content: `Error: ${error.message || "Unknown agent error"}`,
-          });
-          agentState = "paused";
-        }
-      }
-      setState({ loading: false });
-    }
-
+const workflow = createAgentWorkflow(
+  ({ state, setState, addMessage, handleModelResult, tools }) => {
     return {
+      // Set an initial "Ready" message
       initialize: async () => {
-        setState({
-          messages: [
-            {
-              role: "ui",
-              content: "Custom Agent initialized. How can I assist you?",
-            },
-          ],
-        });
+        setState({ messages: [{ role: "ui", content: "Ready." }] });
       },
+      // This is the core loop, called on every user input
       message: async (userInput) => {
-        appendMessage(userInput); // Add to state (auto-appears in state.transcript)
-        if (agentState === "idle" || agentState === "paused") {
-          processLoop();
-        } else {
-          // Agent is already running, show queued status
-          appendMessage({
-            role: "ui",
-            content: "Input queued for processing...",
-          });
-        }
-      },
-      stop: () => {
-        agentState = "paused";
+        addMessage(userInput);
+        setState({ loading: true });
+
+        const result = await generateText({
+          model: openai("gpt-4o"),
+          system: "You are a helpful assistant.",
+          messages: state.transcript, // transcript conveniently excludes UI messages
+          tools,
+        });
+
+        // handleModelResult adds the AI response, executes tools,
+        // and adds tool results to the message history automatically.
+        await handleModelResult(result);
+
         setState({ loading: false });
-        appendMessage({ role: "ui", content: "Agent paused." });
       },
-      terminate: () => {
-        agentState = "idle";
-        setState({ loading: false, messages: [] }); // Clears transcript automatically
-      },
+      // Cleanup methods for user interruption
+      stop: () => setState({ loading: false }),
+      terminate: () => setState({ loading: false, messages: [] }),
     };
   },
 );
 
-run(customWorkflow);
+run(workflow);
 ```
 
-## Why the Codex SDK?
+## Why Codex SDK vs. Other Agents?
 
-- **Reusable UI:** Leverage a polished, interactive terminal interface designed for agent workflows, saving you significant development time.
-- **Secure Tool Integration:** Provides a secure sandbox for executing shell commands and interacting with the file system, managed via the `handleToolCall` mechanism.
-- **Flexible Agent Design:** Bring your own AI models (from any provider like OpenAI, Anthropic, Mistral, or local models via Ollama), prompting strategies, and complex agent logic. The library doesn't impose a specific AI provider.
-- **Built on Vercel AI SDK:** Leverages the robust and extensible [Vercel AI SDK](https://ai-sdk.dev/docs/introduction) for core AI model interactions, providing a standardized way to work with various LLMs.
-- **Focus on Core Logic:** Abstract away the complexities of UI rendering, state management for interactions, and secure tool execution. You concentrate on what makes your agent unique.
+Tools like GitHub Copilot, Cursor, and Claude Code are powerful, integrated assistants. They excel at general-purpose coding tasks but operate within their own fixed systems. You work around their limitations.
 
-## Key Library Components & Usage
+**Codex SDK gives you ultimate control.**
 
-The Codex SDK revolves around a few core exports and concepts for building your agent.
+This is a framework for developers who need to build specialized agents with precise control over the entire workflow. Because you own the agent loop, you can:
 
-### User Interaction Tools for LLMs
+- **Engineer the Perfect Context:** Craft the exact history and system prompts sent to the model. You aren't limited by the context window or prompting strategy of a third-party tool. This precision is key to solving complex, domain-specific problems.
+- **Integrate Custom Tools:** Go beyond simple shell commands. Build any tool you can express in code and integrate it seamlessly into your agent's capabilities.
+- **Define Unique Workflows:** Implement multi-step chains, custom human-in-the-loop approval gates, or complex logic that commercial assistants don't support.
 
-The Codex SDK automatically provides one powerful user interaction tool that LLMs can call autonomously to create human-in-the-loop workflows:
+If you need a highly tailored, powerful, and flexible terminal agent, Codex SDK provides the foundation.
 
-**`user_select`** - Universal user interaction tool
+## How It Works
 
-Handles **confirmations**:
+Codex SDK divides the work of building an agent between the library and your code, letting you focus on the agent's unique logic.
 
-```json
-{
-  "toolName": "user_select",
-  "parameters": {
-    "message": "Should I delete the old backup files?",
-    "options": ["Yes", "No"],
-    "timeout": 45,
-    "defaultValue": "No"
-  }
-}
-```
+**What the SDK Handles:**
 
-Handles **prompted input with suggestions**:
+- **Terminal UI:** Renders the entire interactive experience, including message history, user input, status indicators, and interactive prompts.
+- **State Management:** Orchestrates the application state and ensures the UI always reflects the current status.
+- **Tool Execution & Security:** Manages the secure execution of tools, handling user approvals and sandboxing for file modifications and shell commands.
 
-```json
-{
-  "toolName": "user_select",
-  "parameters": {
-    "message": "What testing framework should I use?",
-    "options": ["Jest", "Vitest", "Mocha"],
-    "timeout": 45,
-    "defaultValue": "Jest"
-  }
-}
-```
+**What You Provide:**
 
-Handles **pure selections**:
+- **The Agent Logic:** You define the core intelligence of your agent. This is where you decide when to call an LLM, what to say, which tools to use, and how to respond to user input.
 
-```json
-{
-  "toolName": "user_select",
-  "parameters": {
-    "message": "Which deployment strategy?",
-    "options": [
-      "Blue-green deployment",
-      "Rolling deployment",
-      "Canary deployment"
-    ],
-    "timeout": 45,
-    "defaultValue": "Rolling deployment"
-  }
-}
-```
+This relationship is managed through a simple event-driven loop. The SDK listens for user input and lifecycle events (like starting or stopping) and calls the corresponding functions in your agent logic. Your code then uses hooks provided by the SDK to update the UI, add messages to the history, and request that tools be executed.
 
-**Important**: `user_select` automatically adds a "None of the above (enter custom option)" choice. When selected:
+For example, when a user sends a message:
 
-- `handleToolCall` returns `null` (no tool response)
-- Agent naturally stops processing (finishReason="stop")
-- User gets normal chat input to provide custom response
-- Perfect for when LLM options don't match user needs
+1.  The SDK captures the input and calls your `message` handler.
+2.  Your code receives the input, calls your preferred LLM with the conversation history, and gets a response.
+3.  Your code uses an SDK hook to add the AI's response to the UI.
+4.  If the AI requested a tool, your code uses another hook to ask the SDK to execute it. The SDK handles the security and approval flow, then returns the result to your logic to continue the loop.
 
-**Normal selections** return: `{"userResponse": "Jest"}`
-**"None of the above"** returns: `null` (enables custom input flow)
+This model gives you full control over the agent's brain while the SDK manages the body.
 
-All interactions include automatic timeout handling (default 45 seconds) and return the user's response in the tool result:
+## Examples
 
-```json
-{"userResponse": "yes"}        // confirmation result
-{"userResponse": "jest"}       // selection result
-{"userResponse": "custom"}     // any selected value
-```
+For more advanced use cases, check out the examples directory:
 
-**Example LLM Workflow:**
+- `examples/simple-agent.js`: The minimal agent from the Quickstart, ready to run.
+- `examples/codebase-quiz.js`: An agent that quizzes you on your own codebase.
+- `examples/text-adventure-game.js`: A mini D&D-style text adventure that shows off advanced display customization and human-in-the-loop interaction.
+- `examples/project-setup-assistant.js`: A multi-step agent that helps set up a new project.
 
-```javascript
-// The LLM can autonomously create interactive workflows using just one tool:
-const response = await generateText({
-  model: openai("gpt-4o"),
-  messages: [...state.transcript],
-  tools, // Automatically includes user_select for all interaction types
-});
+## Security & Approvals
 
-// Examples of what the LLM might call:
-// Confirmation: user_select with Yes/No options
-// Prompted input: user_select with suggestions + "None of the above"
-// Pure selection: user_select with provided options + "None of the above"
+The SDK is designed for safety. When the agent wants to run a shell command or modify files using `handleToolCall`, its capabilities are restricted by an `approvalPolicy`.
 
-// Handle tool calls with natural flow control
-const toolResponse = await handleToolCall(response.toolCalls[0]);
-if (toolResponse) {
-  appendMessage(toolResponse); // Normal tool response - continue processing
-} else if (response.finishReason === "stop") {
-  // User selected "None of the above" - naturally breaks agent loop
-  setState({ loading: false });
-  // User can now provide custom input via normal chat interface
-}
-```
+| Mode          | What the agent may do without asking                        | Still requires approval (managed by the library)                   |
+| ------------- | ----------------------------------------------------------- | ------------------------------------------------------------------ |
+| **Suggest**   | <li>Read any file in the repo                               | <li>**All** file writes/patches<li>**Any** arbitrary shell command |
+| **Auto Edit** | <li>Read **and** apply patches to files                     | <li>**All** shell commands                                         |
+| **Full Auto** | <li>Read/write files <li>Execute shell commands (sandboxed) | -                                                                  |
+
+By default, even in **Full Auto**, commands are run **network-disabled** and confined to the current working directory for defense-in-depth using platform-specific sandboxing (Apple Seatbelt on macOS).
+
+## API Reference
+
+This section provides detailed documentation for the core APIs, display customization, and state management.
 
 ---
 
-### `run(workflow)`
+### `run(workflowFactory, options?)`
 
-Starts the interactive terminal UI, using the provided `workflow` object. This function typically runs until the user exits the UI.
+Starts the terminal UI using your workflow factory.
 
-- **Parameters:**
-  - `workflow` (`object`): The workflow object obtained from either `createDefaultWorkflow` or `createAgentWorkflow`.
-- **Returns:**
-  - `void`
-
----
-
-### `createDefaultWorkflow(options)`
-
-Creates a pre-configured workflow with a default agent, offering an experience similar to the original Codex CLI.
-
-- **Parameters:**
-  - `options` (`object`): Configuration for the default agent.
-    - `options.approvalPolicy` (`AutoApprovalMode` enum: `SUGGEST`, `AUTO_EDIT`, `FULL_AUTO`): Sets the permission mode for the agent.
-    - `options.config` (`object`): UI and tool-specific settings.
-      - `options.config.model` (`string`, optional): The identifier for the AI model to be used (e.g., `"gpt-4o"`, `"o4-mini"`).
-      - `options.config.notify` (`boolean`, optional, default: `true`): Enables/disables desktop notifications.
-      - `options.config.tools` (`object`, optional): Configuration for specific tools.
-        - `options.config.tools.shell` (`object`, optional): Settings for the shell tool.
-          - `options.config.tools.shell.maxBytes` (`number`, optional): Maximum bytes for shell output.
-          - `options.config.tools.shell.maxLines` (`number`, optional): Maximum lines for shell output.
-      - `options.config.fullAutoErrorMode` (`string`, optional, default: `'ask-user'`): Defines error handling behavior in `FULL_AUTO` mode (e.g., `'ask-user'`, `'ignore-and-continue'`).
-    - `options.displayConfig` (`object`, optional): Display customization configuration. Controls how messages, headers, and UI elements are styled. See [Display Customization](#display-customization) section for details.
-- **Returns:**
-  - `object`: A workflow object to be passed to the `run` function.
+- **`workflowFactory`**: The object returned by `createAgentWorkflow`.
+- **`options.approvalPolicy`** (optional): Controls tool approvals (`AutoApprovalMode.SUGGEST`, `AutoApprovalMode.AUTO_EDIT`, `AutoApprovalMode.FULL_AUTO`).
 
 ---
 
 ### `createAgentWorkflow(agentLogicFunction)`
 
-The primary function for building custom agents. It takes your agent's core logic as a function and returns a workflow object.
-
-- **Parameters:**
-  - `agentLogicFunction` (`function`): A function you define that contains your agent's intelligence and interaction loop. See details below.
-- **Returns:**
-  - `object`: A workflow object to be passed to the `run` function.
+Wraps your function into a `WorkflowFactory` the UI can execute. This is the primary helper for building your custom agent. Your function receives a `hooks` object and must return an `AgentObject`.
 
 ---
 
-## Display Customization
+### Display Customization
 
-The Codex SDK provides powerful display customization through the `displayConfig` system, allowing you to customize headers, message labels, colors, borders, and content transformations.
+You can provide a `displayConfig` object from your `agentLogicFunction`'s return value to customize the look and feel of your agent.
 
-### Display Configuration Options
-
-```typescript
-interface DisplayConfig {
-  /** Function to transform the entire message display based on message role */
-  onMessage?: (message: UIMessage) => string;
-
-  /** Custom header for the workflow */
-  header?: string;
-
-  /** Message type customization */
-  messageTypes?: {
-    toolCall?: MessageDisplayOptions;
-    assistant?: MessageDisplayOptions;
-    user?: MessageDisplayOptions;
-    toolResponse?: MessageDisplayOptions;
-    ui?: MessageDisplayOptions;
-  };
-
-  /** Global theme overrides */
-  theme?: ThemeOptions;
-}
-```
-
-### Message Display Options
-
-```typescript
-interface MessageDisplayOptions {
-  /** Simple string label for the message type */
-  label?: string;
-
-  /** Text color (chalk color name, hex, or theme reference) */
-  color?: string;
-
-  /** Whether to display as bold */
-  bold?: boolean;
-
-  /** Container styling */
-  border?: {
-    style?: "single" | "double" | "round" | "bold";
-    color?: string;
-  };
-
-  /** Background color */
-  backgroundColor?: string;
-
-  /** Text color override */
-  textColor?: string;
-
-  /** Margin/padding adjustments */
-  spacing?: {
-    marginLeft?: number;
-    marginTop?: number;
-    marginBottom?: number;
-  };
-}
-```
-
-### Theme System
-
-Define reusable colors that can be referenced throughout your display configuration:
-
-```typescript
-interface ThemeOptions {
-  primary?: string; // Main brand color
-  accent?: string; // Secondary accent color
-  success?: string; // Success/positive color
-  warning?: string; // Warning color
-  error?: string; // Error/danger color
-  muted?: string; // Muted/secondary text color
-}
-```
-
-### Display Customization Examples
-
-**Basic Customization with Custom Header:**
+**Example:**
 
 ```javascript
-const workflow = createAgentWorkflow((hooks) => {
-  // ... your agent logic
-
-  return {
-    displayConfig: {
-      header: "My Custom Agent",
-      messageTypes: {
-        assistant: {
-          label: "🤖 AI Assistant",
-          color: "magentaBright",
-          bold: true,
-        },
-        user: {
-          label: "👤 You",
-          color: "blueBright",
-        },
-      },
-    },
-    // ... other workflow methods
-  };
-});
-```
-
-**Advanced Theming with Content Transformation:**
-
-```javascript
-const workflow = createAgentWorkflow((hooks) => {
-  // ... your agent logic
-
-  return {
-    displayConfig: {
-      header: "Let's play 20 questions!",
-      theme: {
-        primary: "#00ff88",
-        accent: "#ff6b35",
-        success: "#28a745",
-      },
-      onMessage: (message) => {
-        // Transform messages based on their role and content
-        const content = Array.isArray(message.content)
-          ? message.content.find((part) => part.type === "text")?.text || ""
-          : message.content;
-
-        if (message.role === "assistant") {
-          // Check if this is a tool call message
-          if (Array.isArray(message.content)) {
-            const toolCall = message.content.find(
-              (part) => part.type === "tool-call",
-            );
-            if (toolCall?.toolName === "user_select") {
-              const args = toolCall.args;
-              return `❓ ${args.message}\\n📝 Options: ${args.options.map((opt) => opt.label).join(" | ")}`;
-            }
-            if (toolCall) {
-              return "Processing your selection...";
-            }
-          }
-
-          // Regular assistant messages - add game-specific formatting
-          if (content.includes("?")) {
-            return `🎯 ${content}`;
-          }
-          return content;
-        }
-
-        if (message.role === "tool") {
-          // Parse and display user selections clearly
-          if (Array.isArray(message.content)) {
-            const result = message.content.find(
-              (part) => part.type === "tool-result",
-            );
-            if (result?.result) {
-              try {
-                const parsed = JSON.parse(result.result);
-                if (parsed.output) {
-                  return `🎯 You selected: "${parsed.output}"`;
-                }
-              } catch (e) {
-                // fallback
-              }
-            }
-          }
-          return message.content;
-        }
-
-        // Default fallback
-        return content;
-      },
-      messageTypes: {
-        assistant: {
-          label: "🎮 Game Master",
-          color: "primary", // References theme.primary
-        },
-        toolCall: {
-          label: "🎮 Interactive Question",
-          color: "success",
-          border: { style: "round", color: "accent" },
-        },
-        toolResponse: {
-          label: "✅ Your Choice",
-          color: "success",
-        },
-      },
-    },
-    // ... other workflow methods
-  };
-});
-```
-
-**Using with Default Workflow:**
-
-```javascript
-const workflow = createDefaultWorkflow({
-  model: "openai/gpt-4o",
+// In your agentLogicFunction
+return {
   displayConfig: {
-    header: "Custom Code Assistant",
-    theme: {
-      primary: "#007acc",
-      accent: "#f39c12",
-    },
+    header: "My Custom Agent",
     messageTypes: {
-      assistant: {
-        label: "💻 Code Assistant",
-        color: "primary",
-      },
-      user: {
-        label: "👨‍💻 Developer",
-        color: "accent",
-      },
+      assistant: { label: "🤖 AI", color: "magentaBright" },
+      user: { label: "👤 You", color: "blueBright" },
     },
   },
-});
+  // ... other workflow methods
+};
 ```
 
-### Message Types
+#### `DisplayConfig` Object
 
-The system recognizes 5 distinct message types:
-
-- **`assistant`**: Regular AI responses without tool calls
-- **`toolCall`**: AI messages that contain tool calls (detected automatically from content array)
-- **`user`**: User input messages
-- **`toolResponse`**: Results from tool executions
-- **`ui`**: System/status messages from the library
-
-### Color System
-
-Colors can be specified as:
-
-- **Chalk color names**: `"red"`, `"blueBright"`, `"magentaBright"`, etc.
-- **Hex codes**: `"#ff0000"`, `"#00ff88"`, etc.
-- **Theme references**: `"primary"`, `"accent"`, `"success"`, etc. (references your theme colors)
+- **`header`**: A string to display as a custom header for the workflow.
+- **`onMessage`**: A function `(message: UIMessage) => string` that transforms an entire message object into a custom string for display. This gives you full control over how messages are rendered.
+- **`messageTypes`**: An object to customize labels, colors, and borders for different message roles (`assistant`, `user`, `toolCall`, `toolResponse`, `ui`).
+- **`theme`**: An object to define a reusable color palette (`primary`, `accent`, `success`, etc.) that can be referenced by name in other display options.
 
 ---
-
-### WorkflowState Structure
-
-The state managed by your workflow has the following structure:
-
-```typescript
-interface WorkflowState {
-  loading: boolean; // Whether the agent is currently processing
-  messages: Array<UIMessage>; // Array of all messages (user, assistant, tool, ui)
-  inputDisabled: boolean; // Whether user input should be disabled
-  queue?: Array<string>; // Optional queue of pending messages for display
-  transcript?: Array<UIMessage>; // Derived: messages filtered to exclude UI messages
-}
-```
-
-Message types in the `messages` array include:
-
-- **"user"** - User input messages
-- **"assistant"** - AI responses
-- **"tool"** - Tool execution results
-- **"ui"** - Status/system messages
-
-### Queue System
-
-The SDK includes a queue system for displaying pending messages while the agent is processing. This is useful for showing users what requests are queued up during loading states.
-
-- **Visual Display**: The queue appears as a bordered box above the loading indicator, showing numbered items
-- **Consumer-Managed**: Queue contents are entirely managed by your workflow logic
-- **User Flow**: When users type during loading, `message()` is called normally - your workflow decides whether to queue the input
-
-Example usage:
-
-```javascript
-// In your agent workflow - add items to queue
-hooks.setState({ loading: true });
-hooks.addToQueue(["Analyze the data", "Generate report"]);
-
-// Later, process queue items
-const nextItem = hooks.unshiftQueue();
-if (nextItem) {
-  // Process the next item...
-  console.log(`Processing: ${nextItem}`);
-}
-```
-
-### Clean LLM Integration with `state.transcript`
-
-The `state.transcript` property provides a filtered view of messages perfect for LLM calls:
-
-```javascript
-const workflow = createAgentWorkflow(({ state, appendMessage, ... }) => {
-  // Your conversation includes UI messages for user feedback
-  console.log(state.messages.length);     // 8 messages (includes UI status)
-  console.log(state.transcript.length);   // 5 messages (clean LLM input)
-
-  // Perfect for LLM calls - automatically excludes UI messages
-  const response = await generateText({
-    model: openai("gpt-4o"),
-    messages: [
-      { role: "system", content: "You are a helpful assistant." },
-      ...state.transcript, // Clean conversation history
-    ],
-    tools,
-  });
-});
-```
 
 ### The `agentLogicFunction(hooks)`
 
-This is the function you provide to `createAgentWorkflow`. It's where your custom agent's intelligence and main processing loop reside. The SDK calls this function, providing it with a `hooks` object to interact with the UI and tools.
+This is the function you provide to `createAgentWorkflow`. It's where your agent's intelligence resides. It receives a `hooks` object with the following properties:
 
-- **Parameters (provided by the SDK to your function):**
-
-  - `hooks` (`object`): An object containing functions and data to interact with the SDK:
-    - `hooks.setState(state)` (`function`): Updates the workflow state declaratively.
-      - **Input:** `state` (`Partial<WorkflowState> | ((prev: WorkflowState) => WorkflowState)`): Either a partial state object to merge or an updater function.
-      - **Returns:** `Promise<void>`: Promise that resolves when UI has been updated (for compatibility).
-      - **Synchronous behavior:** State changes are applied immediately and are visible via `state.loading` without awaiting.
-      - **Merging behavior:** Like React's setState, only top-level properties are merged. Arrays and nested objects are replaced entirely. To append messages, use `appendMessage()` or the function form: `setState(prev => ({ ...prev, messages: [...prev.messages, newMsg] }))`.
-    - `hooks.state` (`object`): Current workflow state with getter properties.
-      - **Synchronous access:** Properties reflect current state immediately, including any changes made by recent `setState()` calls.
-      - **Properties:**
-        - `state.loading` - Whether the agent is currently processing
-        - `state.messages` - Array of all messages (user, assistant, tool, ui)
-        - `state.inputDisabled` - Whether user input should be disabled
-        - `state.queue` - Array of queued messages for display
-        - `state.transcript` - **Derived property:** Messages filtered to exclude UI messages (perfect for LLM calls)
-      - **Usage:** Access via `hooks.state.loading` instead of `hooks.getState().loading`.
-    - `hooks.appendMessage(message)` (`function`): Appends message(s) to the current messages array.
-      - **Input:** `message` (`UIMessage | Array<UIMessage>`): A single message or array of messages to append.
-      - **Returns:** `void`.
-      - **Usage:** This is a convenience method for the common operation of appending messages. Equivalent to `setState(prev => ({ ...prev, messages: [...prev.messages, ...messages] }))`.
-    - `hooks.addToQueue(item)` (`function`): Adds item(s) to the end of the queue.
-      - **Input:** `item` (`string | Array<string>`): Single string or array of strings to add to the queue.
-      - **Returns:** `void`.
-      - **Usage:** Convenience method for adding items to the queue. Equivalent to `setState(prev => ({ ...prev, queue: [...(prev.queue || []), ...items] }))`.
-    - `hooks.unshiftQueue()` (`function`): Removes and returns the first item from the queue.
-      - **Returns:** `string | undefined`: The first queue item, or `undefined` if queue is empty.
-      - **Usage:** Convenience method for consuming queue items. Equivalent to manually checking queue length, getting first item, and updating state to remove it.
-    - `hooks.handleToolCall(aiMessageWithToolCall)` (`function`): Executes tool calls requested by the AI.
-      - **Input:** `aiMessageWithToolCall` (`object`): The AI's message object that includes a `tool_calls` array.
-      - **Returns:** `Promise<object | null>`: A promise that resolves to a tool response message (for the AI and UI) or `null` if no specific response is needed beyond the tool's side effects.
-    - `hooks.tools` (`Array<object>`): An array of tool definitions that the library supports (e.g., for shell commands, file operations, and user interactions). You should pass these to your AI model so it knows what tools it can request.
-    - `hooks.onConfirm(prompt, options?)` (`function`): **Deprecated** - Use `onSelect` with Yes/No options instead.
-    - `hooks.onPrompt(message, options?)` (`function`): **Deprecated** - Use `onSelect` with suggested options instead.
-    - `hooks.onSelect(items, options?)` (`function`): Shows a selection dialog to the user.
-      - **Input:** `items` (`Array<{label: string, value: string}>`): Items to choose from.
-      - **Input:** `options` (`object`, optional): Selection options.
-        - `options.required` (`boolean`, optional): Whether selection is required.
-        - `options.default` (`string`, optional): Default value for escape key.
-        - `options.label` (`string`, optional): Custom label for the selection.
-        - `options.timeout` (`number`, optional): Timeout in seconds after which default value is automatically selected.
-        - `options.defaultValue` (`string`, required if timeout specified): Default value to use when timeout expires (must match one of the item values).
-      - **Returns:** `Promise<string>`: The selected value.
-    - `hooks.logger(message)` (`function`): Logs debug messages.
-      - **Input:** `message` (`string`): The message to log.
-      - **Returns:** `void`.
-    - `hooks.onError(error)` (`function`, optional): Error handler callback.
-      - **Input:** `error` (`unknown`): The error that occurred.
-      - **Returns:** `void`.
-
-- **Returns (your function must return this):**
-  - `AgentObject` (`object`): An object that defines the interface the SDK will use to interact with and control your agent. See details below.
+- **`state`**: A read-only object containing the current workflow state:
+  - `loading`: `boolean` - Whether the agent is currently processing.
+  - `messages`: `Array<UIMessage>` - The complete history of all message types.
+  - `inputDisabled`: `boolean` - Whether the user input is currently disabled.
+  - `queue`: `Array<string>` - The current queue of pending tasks for display.
+  - `transcript`: `Array<UIMessage>` - A clean version of `messages` excluding "ui" messages, perfect for sending to an LLM.
+- **`setState(newState)`**: Updates the workflow state. It merges top-level properties, like React's `setState`.
+- **`addMessage(message)`**: A convenience method to append one or more messages to the history.
+- **`tools`**: An array of tool definitions that the library supports. Pass these to your AI model so it knows what tools it can call.
+- **`handleModelResult(result)`**: A powerful convenience function that takes the raw result from an AI model call and orchestrates the next steps: it adds the AI's response messages to the history, securely executes any requested tool calls, and then adds the tool results back to the history, returning the tool responses.
+- **`handleToolCall(messages)`**: The underlying function to execute tool calls requested by the AI. `handleModelResult` uses this internally.
+- **`onSelect(items, options?)`**: Prompts the user to choose from a list of options. Returns a promise with the selected value.
+- **`onConfirm(message, options?)`**: Prompts the user with a yes/no question. Returns a promise with the boolean result.
+- **`onPrompt(message, options?)`**: Prompts the user for freeform text input. Returns a promise with the string result.
+- **`addToQueue(items)` / `unshiftQueue()`**: Methods to manage the task queue displayed in the UI.
+- **`logger(message)`**: A function to log debug messages.
+- **`onError(error)`**: An optional error handler callback for the workflow.
 
 ---
 
 ### The `AgentObject` (returned by your `agentLogicFunction`)
 
-This is the object your `agentLogicFunction` must return. It defines the lifecycle and interaction methods for your custom agent.
+This is the object your `agentLogicFunction` must return. It defines the lifecycle methods for your agent.
 
-- **Properties (all are methods you implement):**
-  - `initialize()`:
-    - **Purpose:** Called once when the agent workflow starts. Use for setup, sending initial greetings (via `hooks.onUIMessage`), or preparing system prompts.
-    - **Parameters:** None.
-    - **Returns:** `Promise<void>`.
-  - `message(userInputMessage)`:
-    - **Purpose:** Called whenever the user submits new input. This is the entry point for your agent to process user requests.
-    - **Parameters:**
-      - `userInputMessage` (`object`): The user's input, typically `{ role: 'user', content: '...' }`.
-    - **Returns:** `Promise<void>`.
-  - `stop()`:
-    - **Purpose:** Called if the user requests to pause or interrupt the agent (e.g., by pressing `Escape` twice). Your agent should halt its current processing loop and preserve its state if possible.
-    - **Parameters:** None.
-    - **Returns:** `void`.
-  - `terminate()`:
-    - **Purpose:** Called if the user requests to end the session or reset the agent (e.g., by pressing `Ctrl+C`). Your agent should stop all processing, clear its state and transcript, and prepare for a potential new session or full shutdown.
-    - **Parameters:** None.
-    - **Returns:** `void`.
+- **`initialize()`**: Called once when the agent starts. Use for setup or sending a welcome message.
+- **`message(userInputMessage)`**: Called whenever the user submits input. This is the main entry point for your agent's processing loop.
+- **`stop()`**: Called when the user interrupts the agent (e.g., `Esc`). Your agent should halt processing.
+- **`terminate()`**: Called when the user quits (e.g., `Ctrl+C`). Your agent should stop and clear its state.
+- **`commands`**: An object defining custom slash commands (e.g., `/compact`) that can be triggered by the user from the input line.
+- **`displayConfig`**: The display configuration object described above.
 
 ---
 
-## Security Model & Permissions
+### `WorkflowState` Structure
 
-The Codex SDK helps you build agents that can interact with the system, such as running shell commands or modifying files. The security model is designed to provide safety and control.
+The `state` object managed by your workflow has the following structure:
 
-When using `handleToolCall` for operations like shell commands, these are executed with restrictions:
-| Mode | What the agent may do without asking (via `handleToolCall`) | Still requires approval (managed by library's UI/tool handler) |
-| ------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| **Suggest** <br>(default with `createDefaultWorkflow`) | <li>Read any file in the repo | <li>**All** file writes/patches<li> **Any** arbitrary shell commands (aside from reading files) |
-| **Auto Edit** | <li>Read **and** apply-patch writes to files | <li>**All** shell commands |
-| **Full Auto** | <li>Read/write files <li> Execute shell commands (network disabled, writes limited to your workdir) | - |
+```typescript
+interface WorkflowState {
+  loading: boolean;
+  messages: Array<UIMessage>;
+  inputDisabled: boolean;
+  queue?: Array<string>; // Optional queue of pending messages
+  transcript?: Array<UIMessage>; // Derived: messages filtered to exclude UI messages
+}
+```
 
-For custom agents built with `createAgentWorkflow`, how `approvalMode` (or a similar concept) is handled depends on your implementation. The `handleToolCall` function will respect the sandboxing rules, but your agent logic determines when and what tools are called. You can implement custom approval flows using `onUIMessage` and user responses.
+The `state.transcript` property provides a clean message history (excluding "ui" messages) that is perfect for sending to an LLM.
 
-By default, in modes like **Full Auto**, commands are run **network-disabled** and confined to the current working directory (plus temporary files) for defense-in-depth.
-
-### Platform Sandboxing Details
-
-The hardening mechanism used by the Codex SDK's tool execution depends on your OS:
-
-- **macOS 12+** - commands are wrapped with **Apple Seatbelt** (`sandbox-exec`).
-  - Everything is placed in a read-only jail except for a small set of writable roots (`$PWD`, `$TMPDIR`, etc.).
-  - Outbound network is _fully blocked_ by default.
-- **Linux** - Sandboxing might require user-side setup (e.g., Docker).
-  The Codex SDK itself does not enforce Linux sandboxing beyond what Node.js child_process offers. For stronger isolation, consider running your Node.js application that uses this library within a containerized environment like Docker, similar to the recommendations for the original CLI.
+---
 
 ## License
 

--- a/codex-sdk/examples/queue-demo.js
+++ b/codex-sdk/examples/queue-demo.js
@@ -1,7 +1,7 @@
 import { run, createAgentWorkflow } from "../dist/lib.js";
 
 const queueDemoWorkflow = createAgentWorkflow(
-  ({ setState, appendMessage, addToQueue, unshiftQueue }) => {
+  ({ setState, addMessage, addToQueue, unshiftQueue }) => {
     let processing = false;
 
     async function processNextInQueue() {
@@ -14,14 +14,14 @@ const queueDemoWorkflow = createAgentWorkflow(
 
       let nextMessage = unshiftQueue();
       while (nextMessage) {
-        appendMessage({
+        addMessage({
           role: "assistant",
           content: `Processing: "${nextMessage}"`,
         });
 
         await new Promise((resolve) => setTimeout(resolve, 2000));
 
-        appendMessage({
+        addMessage({
           role: "assistant",
           content: `Completed: "${nextMessage}"`,
         });
@@ -35,7 +35,7 @@ const queueDemoWorkflow = createAgentWorkflow(
 
     return {
       initialize: async () => {
-        appendMessage({
+        addMessage({
           role: "ui",
           content:
             "Queue Demo Agent ready! Type messages to see them queued while processing.",
@@ -45,10 +45,10 @@ const queueDemoWorkflow = createAgentWorkflow(
       message: async (input) => {
         const userMessage = input.content;
 
-        appendMessage(input);
+        addMessage(input);
         addToQueue(userMessage);
 
-        appendMessage({
+        addMessage({
           role: "ui",
           content: `Added "${userMessage}" to queue`,
         });
@@ -59,7 +59,7 @@ const queueDemoWorkflow = createAgentWorkflow(
       stop: () => {
         processing = false;
         setState({ loading: false });
-        appendMessage({
+        addMessage({
           role: "ui",
           content: "Processing stopped. Queue preserved.",
         });

--- a/codex-sdk/src/workflow/default-agent.ts
+++ b/codex-sdk/src/workflow/default-agent.ts
@@ -114,7 +114,7 @@ export function defaultWorkflow(
     if (mcpClientManager && !mcpInitialized) {
       try {
         hooks.logger("Initializing MCP Client Manager...");
-        hooks.appendMessage({
+        hooks.addMessage({
           role: "ui",
           content: "Initializing MCP Client Manager...",
         });
@@ -123,11 +123,11 @@ export function defaultWorkflow(
         mcpInitialized = true;
         const msg = `MCP Client Manager initialized. Tools found: ${Object.keys(mcpTools).join(", ") || "None"}`;
         hooks.logger(msg);
-        hooks.appendMessage({ role: "ui", content: msg });
+        hooks.addMessage({ role: "ui", content: msg });
       } catch (error) {
         const errorMsg = `Error initializing MCP Client Manager: ${error instanceof Error ? error.message : String(error)}`;
         hooks.logger(errorMsg);
-        hooks.appendMessage({ role: "ui", content: errorMsg });
+        hooks.addMessage({ role: "ui", content: errorMsg });
         // Optionally, handle this error more gracefully, e.g., by notifying the user
       }
     }
@@ -156,7 +156,7 @@ export function defaultWorkflow(
       }
 
       hooks.setState({ loading: false });
-      hooks.appendMessage({
+      hooks.addMessage({
         role: "ui",
         content: "⏹️  Execution interrupted by user. You can continue typing.",
       });
@@ -182,13 +182,13 @@ export function defaultWorkflow(
 
       if (mcpClientManager) {
         hooks.logger("Closing MCP Client Manager...");
-        hooks.appendMessage({
+        hooks.addMessage({
           role: "ui",
           content: "Closing MCP Client Manager connections...",
         });
         await mcpClientManager.closeAll();
         hooks.logger("MCP Client Manager closed.");
-        hooks.appendMessage({
+        hooks.addMessage({
           role: "ui",
           content: "MCP Client Manager connections closed.",
         });
@@ -206,7 +206,7 @@ export function defaultWorkflow(
 
       // Add input messages to transcript and UI
       transcript.push(input);
-      hooks.appendMessage(input);
+      hooks.addMessage(input);
 
       // Set up loop control variables
       let isRunning = true;
@@ -256,7 +256,7 @@ export function defaultWorkflow(
               // Add to transcript
               transcript.push(message);
               // Send to UI
-              hooks.appendMessage(message);
+              hooks.addMessage(message);
 
               // Check for tool calls
               const toolCall = getToolCall(message);
@@ -291,11 +291,11 @@ export function defaultWorkflow(
                       ],
                     };
                     transcript.push(toolResponseMessage);
-                    hooks.appendMessage(toolResponseMessage);
+                    hooks.addMessage(toolResponseMessage);
                   } catch (mcpError) {
                     const errorText = `Error calling MCP tool ${toolCall.toolName}: ${mcpError}`;
                     hooks.logger(errorText);
-                    hooks.appendMessage({ role: "ui", content: errorText });
+                    hooks.addMessage({ role: "ui", content: errorText });
                     const errorResult: ModelMessage = {
                       role: "tool",
                       content: [
@@ -311,14 +311,14 @@ export function defaultWorkflow(
                       ],
                     };
                     transcript.push(errorResult);
-                    hooks.appendMessage(errorResult);
+                    hooks.addMessage(errorResult);
                   }
                 } else {
                   // Handle as a local tool
                   const toolResult = await hooks.handleToolCall(message);
                   if (toolResult) {
                     transcript.push(toolResult);
-                    hooks.appendMessage(toolResult);
+                    hooks.addMessage(toolResult);
                   }
                 }
               }
@@ -336,7 +336,7 @@ export function defaultWorkflow(
           // Log the error and end the loop
           const runErrorMsg = `Error in workflow run: ${(error as Error).message}`;
           hooks.logger(runErrorMsg);
-          hooks.appendMessage({ role: "ui", content: runErrorMsg });
+          hooks.addMessage({ role: "ui", content: runErrorMsg });
 
           // Call the error handler if provided
           if (hooks.onError) {
@@ -407,7 +407,7 @@ Keep the summary concise but comprehensive.`,
             });
 
             // Notify the hooks
-            hooks.appendMessage({
+            hooks.addMessage({
               role: "ui",
               content: "Conversation context compacted successfully.",
             });
@@ -416,7 +416,7 @@ Keep the summary concise but comprehensive.`,
           } catch (error) {
             const errorMsg = `Error executing /compact command: ${(error as Error).message}`;
             hooks.logger(errorMsg);
-            hooks.appendMessage({ role: "ui", content: errorMsg });
+            hooks.addMessage({ role: "ui", content: errorMsg });
             hooks.setState({ loading: false });
           }
         },
@@ -436,14 +436,14 @@ Keep the summary concise but comprehensive.`,
               content = "`/diff` — _not inside a git repository_";
             }
 
-            hooks.appendMessage({
+            hooks.addMessage({
               role: "system",
               content: content,
             });
           } catch (error) {
             const errorMsg = `Error executing /diff command: ${(error as Error).message}`;
             hooks.logger(errorMsg);
-            hooks.appendMessage({ role: "ui", content: errorMsg });
+            hooks.addMessage({ role: "ui", content: errorMsg });
           }
         },
       },

--- a/codex-sdk/tests/declarative-state-api.test.ts
+++ b/codex-sdk/tests/declarative-state-api.test.ts
@@ -152,7 +152,7 @@ describe("Declarative State API", () => {
     });
   });
 
-  describe("appendMessage behavior", () => {
+  describe("addMessage behavior", () => {
     it("should append a single message", () => {
       let currentState: WorkflowState = {
         loading: false,
@@ -160,7 +160,7 @@ describe("Declarative State API", () => {
         inputDisabled: false,
       };
 
-      const mockAppendMessage = (message: any) => {
+      const mockAddMessage = (message: any) => {
         const messages = Array.isArray(message) ? message : [message];
         currentState = {
           ...currentState,
@@ -168,7 +168,7 @@ describe("Declarative State API", () => {
         };
       };
 
-      mockAppendMessage({ role: "assistant", content: "Hi there!" });
+      mockAddMessage({ role: "assistant", content: "Hi there!" });
 
       expect(currentState.messages).toHaveLength(2);
       expect(currentState.messages[1]).toEqual({
@@ -184,7 +184,7 @@ describe("Declarative State API", () => {
         inputDisabled: false,
       };
 
-      const mockAppendMessage = (message: any) => {
+      const mockAddMessage = (message: any) => {
         const messages = Array.isArray(message) ? message : [message];
         currentState = {
           ...currentState,
@@ -197,7 +197,7 @@ describe("Declarative State API", () => {
         { role: "assistant", content: "Message 2" },
       ];
 
-      mockAppendMessage(newMessages);
+      mockAddMessage(newMessages);
 
       expect(currentState.messages).toHaveLength(3);
       expect(currentState.messages[1]).toEqual({
@@ -217,7 +217,7 @@ describe("Declarative State API", () => {
         inputDisabled: true,
       };
 
-      const mockAppendMessage = (message: any) => {
+      const mockAddMessage = (message: any) => {
         const messages = Array.isArray(message) ? message : [message];
         currentState = {
           ...currentState,
@@ -225,7 +225,7 @@ describe("Declarative State API", () => {
         };
       };
 
-      mockAppendMessage({ role: "ui", content: "Test message" });
+      mockAddMessage({ role: "ui", content: "Test message" });
 
       expect(currentState).toEqual({
         loading: true,
@@ -246,7 +246,7 @@ describe("Declarative State API", () => {
           queue: [],
           transcript: [],
         },
-        appendMessage: vi.fn(),
+        addMessage: vi.fn(),
         addToQueue: vi.fn(),
         unshiftQueue: vi.fn(() => undefined),
         tools: {},
@@ -255,6 +255,7 @@ describe("Declarative State API", () => {
         onPrompt: vi.fn(),
         onSelect: vi.fn(),
         logger: vi.fn(),
+        handleModelResult: vi.fn(),
       };
 
       const workflow = createAgentWorkflow((hooks) => {
@@ -313,7 +314,7 @@ describe("Declarative State API", () => {
             return workflowState.messages.filter((msg) => msg.role !== "ui");
           },
         },
-        appendMessage: vi.fn(),
+        addMessage: vi.fn(),
         addToQueue: vi.fn(),
         unshiftQueue: vi.fn(() => undefined),
         tools: {},
@@ -322,6 +323,7 @@ describe("Declarative State API", () => {
         onPrompt: vi.fn(),
         onSelect: vi.fn(),
         logger: vi.fn(),
+        handleModelResult: vi.fn(),
       };
 
       const workflow = createAgentWorkflow((hooks) => {
@@ -450,7 +452,7 @@ describe("Declarative State API", () => {
               return state.messages.filter((msg) => msg.role !== "ui");
             },
           },
-          appendMessage: vi.fn(),
+          addMessage: vi.fn(),
           addToQueue: vi.fn(),
           unshiftQueue: vi.fn(() => undefined),
           tools: {},
@@ -459,6 +461,7 @@ describe("Declarative State API", () => {
           onPrompt: vi.fn(),
           onSelect: vi.fn(),
           logger: vi.fn(),
+          handleModelResult: vi.fn(),
         };
       };
 

--- a/codex-sdk/tsconfig.json
+++ b/codex-sdk/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": ".",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "target": "esnext",


### PR DESCRIPTION
### Summary
- Renamed appendMessage → addMessage with array support.
- Array-in/array-out tool flow: handleToolCall accepts arrays; examples/README updated to treat messages as arrays.
- New helper: handleModelResult(result) = add messages → run tools → add tool responses.
- README overhaul: Vercel AI SDK v5 front-and-center; clarified purpose; default workflow de-emphasized.
- Examples updated for simpler, consistent loops.

### Motivation
- Reduce boilerplate in agent loops and standardize message handling.
- Align docs with actual API and emphasize Vercel AI SDK v5 integration.
- Make it obvious this is a framework to build terminal agents (not a CLI), and keep default workflow below the fold.

### Key changes

- API
  - WorkflowHooks
    - addMessage(message: UIMessage | UIMessage[]): new name and array support (replaces appendMessage).
    - handleToolCall(input): now supports ModelMessage | ModelMessage[] and returns single or array respectively. Array-in/array-out enables clean call sites.
    - handleModelResult(result): convenience helper; equivalent to:
      - const messages = result.response.messages;
      - addMessage(messages);
      - const toolResponses = await handleToolCall(messages);
      - addMessage(toolResponses);
      - Returns toolResponses array (possibly empty).
- Implementation
  - codex-sdk/src/components/chat/terminal-chat.tsx
    - Implemented addMessage with array support.
    - Implemented array-aware handleToolCall with user_select and shell/apply_patch support.
    - Added handleModelResult; normalizes to arrays; pushes messages and tool responses.
- Docs (README.md)
  - Vercel AI SDK v5 required highlighted in Requirements and Quickstart.
  - De-emphasized default workflow; fixed usage (approvalPolicy passed to run(...)).
  - Updated examples to use array-based addMessage + handleToolCall and handleModelResult.
  - Clarified user_select input schema (no timeout arg; UI enforces 45s).
  - Added API overview for handleModelResult and array semantics.
- Examples
  - codex-sdk/examples/custom-workflow.js
    - Uses await handleModelResult(result), then parses toolResponses to update game state.
  - codex-sdk/examples/project-setup-assistant.js
    - Uses await handleModelResult(result).
  - codex-sdk/examples/codebase-quiz.js
    - Uses await handleModelResult(result). Checks toolResponses.length === 0 for “None of the above” path.
  - codex-sdk/examples/queue-demo.js
    - Previously refactored to addMessage and batched message arrays.
- Tests
  - Updated declarative-state-api test naming (appendMessage → addMessage) and mocks.

### Breaking changes
- appendMessage removed; use addMessage(message: UIMessage | UIMessage[]).
- If you depended on handleToolCall returning a single value when passing a single message, that still works. For arrays, you’ll now get an array (possibly empty).

### Migration guide
- Replace:
  - appendMessage(x) → addMessage(x)
  - const ai = result.response.messages[0]; addMessage(ai); const tr = await handleToolCall(ai); if (tr) addMessage(tr);
- With either:
  - addMessage(result.response.messages);
  - const toolResponses = await handleToolCall(result.response.messages);
  - addMessage(toolResponses);
- Or the one‑liner:
  - await handleModelResult(result);

### Notes
- Empty arrays to addMessage are no-ops.
- Array input to handleToolCall returns an array; examples assume this and avoid length guards except where needed for logic (e.g., custom input path).

### Checklist
- [x] API and examples compile with new naming and signatures
- [x] README reflects Vercel AI SDK v5, explains handleModelResult, and de-emphasizes default workflow
- [x] Lints pass on changed files